### PR TITLE
feat: Step 2 - 型定義の作成

### DIFF
--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,0 +1,45 @@
+// Popup ↔ Service Worker 間のメッセージ型定義
+
+export type RequestMessage =
+  | { action: 'SAVE_API_KEY'; payload: { plainKey: string } }
+  | { action: 'GET_API_KEY_STATUS' }
+  | { action: 'DELETE_API_KEY' }
+  | { action: 'SEARCH_CUSTOMER'; payload: { teamId: string } }
+  | { action: 'LIST_SUBSCRIPTIONS'; payload: { customerId: string } }
+  | { action: 'CANCEL_SUBSCRIPTION'; payload: { subscriptionId: string } }
+  | { action: 'LIST_INVOICES'; payload: { customerId: string } }
+  | { action: 'ADD_CASH_BALANCE'; payload: { customerId: string; amount: number } }
+
+export type ResponseMessage<T = unknown> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; code?: string }
+
+// 各アクションのレスポンスデータ型
+
+export interface ApiKeyStatusData {
+  exists: boolean
+  maskedKey?: string // 例: "sk_test_...AbCd"
+}
+
+export interface SearchCustomerData {
+  customers: import('./stripe').StripeCustomer[]
+}
+
+export interface ListSubscriptionsData {
+  subscriptions: import('./stripe').StripeSubscription[]
+}
+
+export interface CancelSubscriptionData {
+  subscriptionId: string
+  status: string
+}
+
+export interface ListInvoicesData {
+  invoices: import('./stripe').StripeInvoice[]
+}
+
+export interface AddCashBalanceData {
+  customerId: string
+  amount: number
+  currency: string
+}

--- a/src/types/stripe.ts
+++ b/src/types/stripe.ts
@@ -1,0 +1,118 @@
+// Stripe API レスポンス型定義
+
+export interface StripeCustomer {
+  id: string
+  object: 'customer'
+  email: string | null
+  name: string | null
+  metadata: Record<string, string>
+  created: number
+  currency: string | null
+  balance: number
+  cash_balance: StripeCashBalance | null
+}
+
+export interface StripeCashBalance {
+  object: 'cash_balance'
+  available: Record<string, number> | null
+  customer: string
+  livemode: boolean
+}
+
+export interface StripeSubscription {
+  id: string
+  object: 'subscription'
+  customer: string
+  status: StripeSubscriptionStatus
+  items: {
+    data: StripeSubscriptionItem[]
+  }
+  current_period_start: number
+  current_period_end: number
+  created: number
+  cancel_at_period_end: boolean
+  canceled_at: number | null
+}
+
+export type StripeSubscriptionStatus =
+  | 'active'
+  | 'canceled'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'past_due'
+  | 'paused'
+  | 'trialing'
+  | 'unpaid'
+
+export interface StripeSubscriptionItem {
+  id: string
+  object: 'subscription_item'
+  price: StripePrice
+  quantity: number
+}
+
+export interface StripePrice {
+  id: string
+  object: 'price'
+  currency: string
+  unit_amount: number | null
+  recurring: {
+    interval: 'day' | 'week' | 'month' | 'year'
+    interval_count: number
+  } | null
+  product: string | StripeProduct
+}
+
+export interface StripeProduct {
+  id: string
+  object: 'product'
+  name: string
+  active: boolean
+}
+
+export interface StripeInvoice {
+  id: string
+  object: 'invoice'
+  customer: string
+  subscription: string | null
+  status: StripeInvoiceStatus
+  amount_due: number
+  amount_paid: number
+  amount_remaining: number
+  currency: string
+  created: number
+  due_date: number | null
+  description: string | null
+  number: string | null
+}
+
+export type StripeInvoiceStatus =
+  | 'draft'
+  | 'open'
+  | 'paid'
+  | 'uncollectible'
+  | 'void'
+
+export interface StripeListResponse<T> {
+  object: 'list'
+  data: T[]
+  has_more: boolean
+  url: string
+}
+
+export interface StripeSearchResponse<T> {
+  object: 'search_result'
+  data: T[]
+  has_more: boolean
+  next_page: string | null
+  url: string
+}
+
+export interface StripeError {
+  error: {
+    type: string
+    code?: string
+    message: string
+    param?: string
+  }
+}


### PR DESCRIPTION
## Summary
- `src/types/messages.ts`: Popup↔ServiceWorker間のメッセージ型をディスクリミネーテッドユニオンで定義
- `src/types/stripe.ts`: Stripe APIレスポンス型（Customer / Subscription / Invoice / Price / Product 等）を定義

## 型設計のポイント
- `RequestMessage` は `action` フィールドでユニオン判別
- `ResponseMessage<T>` は `ok: true/false` で成功/失敗を判別
- 各アクションのレスポンスデータ型（`ApiKeyStatusData` 等）も定義済み
- `StripeSubscriptionStatus` / `StripeInvoiceStatus` はリテラル型で網羅

## Test plan
- [ ] `npx tsc --noEmit` でエラーなし

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)