### PR TITLE
feat: Step 6 (S01〜S03) - APIキー設定・顧客検索・操作メニュー画面

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -3,22 +3,25 @@
 // Popup エントリポイント
 // 画面遷移とService Workerとの通信を管理
 
-import type { RequestMessage, ResponseMessage } from '../types/messages'
 import type { AppState, ScreenId, Screen } from './types'
 import { createLoadingSpinner } from './components/loading-spinner'
+import { sendMessage } from './send-message'
+import { s01ApiKey } from './screens/s01-api-key'
+import { s02Search } from './screens/s02-search'
+import { s03Menu } from './screens/s03-menu'
 
 // アプリケーション状態
 const appState: AppState = {}
 
-// 画面マップ（Step 6で各画面を実装）
+// 画面マップ
 const screens: Record<ScreenId, Screen> = {
-  S01: createPlaceholderScreen('S01', 'APIキー設定画面'),
-  S02: createPlaceholderScreen('S02', '顧客検索画面'),
-  S03: createPlaceholderScreen('S03', 'サブスクリプション一覧画面'),
-  S04: createPlaceholderScreen('S04', 'サブスクリプションキャンセル確認画面'),
-  S05: createPlaceholderScreen('S05', 'インボイス一覧画面'),
-  S06: createPlaceholderScreen('S06', 'インボイス詳細画面'),
-  S07: createPlaceholderScreen('S07', 'キャッシュ残高追加画面'),
+  S01: s01ApiKey,
+  S02: s02Search,
+  S03: s03Menu,
+  S04: createPlaceholderScreen('S04', 'サブスクリプション一覧'),
+  S05: createPlaceholderScreen('S05', 'キャンセル確認'),
+  S06: createPlaceholderScreen('S06', 'Invoice一覧'),
+  S07: createPlaceholderScreen('S07', '残高追加確認'),
 }
 
 /**
@@ -125,27 +128,7 @@ export function navigate(screenId: ScreenId, stateUpdate?: Partial<AppState>): v
   app.replaceChildren(screen.render(appState, navigate))
 }
 
-/**
- * Service Workerにメッセージを送信する
- * @param message リクエストメッセージ
- * @returns レスポンスメッセージ
- */
-export async function sendMessage<T = unknown>(message: RequestMessage): Promise<ResponseMessage<T>> {
-  return new Promise((resolve) => {
-    chrome.runtime.sendMessage(message, (response: ResponseMessage<T>) => {
-      // エラーチェック
-      if (chrome.runtime.lastError) {
-        resolve({
-          ok: false,
-          error: chrome.runtime.lastError.message || 'メッセージ送信に失敗しました',
-        })
-        return
-      }
-
-      resolve(response)
-    })
-  })
-}
+export { sendMessage } from './send-message'
 
 /**
  * アプリケーション初期化

--- a/src/popup/screens/s01-api-key.ts
+++ b/src/popup/screens/s01-api-key.ts
@@ -1,0 +1,228 @@
+// S01: APIキー設定画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import { sendMessage } from '../send-message'
+import { createLoadingSpinner } from '../components/loading-spinner'
+
+export const s01ApiKey: Screen = {
+  render(_state: AppState, navigate: NavigateFn): HTMLElement {
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 20px 24px 16px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+    `)
+    const logo = div(`
+      width: 32px;
+      height: 32px;
+      background: #635bff;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 16px;
+      font-weight: 700;
+      flex-shrink: 0;
+    `)
+    logo.textContent = 'S'
+    const title = el('h1', 'Stripe Test Helper', `
+      font-size: 16px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `)
+    header.appendChild(logo)
+    header.appendChild(title)
+    container.appendChild(header)
+
+    // ── 本文 ──
+    const body = div(`
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 32px 24px;
+    `)
+
+    const card = div(`
+      background: #fff;
+      border-radius: 12px;
+      padding: 28px 24px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+    `)
+
+    const cardTitle = el('h2', 'APIキーを設定', `
+      font-size: 18px;
+      font-weight: 700;
+      color: #1a1a2e;
+      margin-bottom: 8px;
+    `)
+    const cardDesc = el('p', 'テスト用のStripe APIキー（sk_test_）を入力してください。', `
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.6;
+      margin-bottom: 24px;
+    `)
+
+    // 入力フィールド
+    const inputWrap = div(`position: relative; margin-bottom: 8px;`)
+    const input = document.createElement('input')
+    input.type = 'password'
+    input.placeholder = 'sk_test_...'
+    input.autocomplete = 'off'
+    input.spellcheck = false
+    input.style.cssText = `
+      width: 100%;
+      padding: 10px 44px 10px 12px;
+      border: 1.5px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 13px;
+      font-family: 'Menlo', 'Monaco', monospace;
+      color: #1a1a2e;
+      background: #f9fafb;
+      outline: none;
+      transition: border-color 0.15s;
+      box-sizing: border-box;
+    `
+    input.addEventListener('focus', () => { input.style.borderColor = '#635bff' })
+    input.addEventListener('blur', () => { input.style.borderColor = '#e5e7eb' })
+
+    // 表示/非表示トグル
+    const toggle = div(`
+      position: absolute;
+      right: 10px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+      color: #9ca3af;
+      font-size: 16px;
+      user-select: none;
+      line-height: 1;
+    `)
+    toggle.textContent = '👁'
+    let visible = false
+    toggle.addEventListener('click', () => {
+      visible = !visible
+      input.type = visible ? 'text' : 'password'
+      toggle.style.opacity = visible ? '1' : '0.5'
+    })
+    toggle.style.opacity = '0.5'
+
+    inputWrap.appendChild(input)
+    inputWrap.appendChild(toggle)
+
+    // エラーメッセージ
+    const errorText = el('p', '', `
+      font-size: 12px;
+      color: #dc2626;
+      min-height: 18px;
+      margin-bottom: 16px;
+      line-height: 1.4;
+    `)
+
+    // 保存ボタン
+    const saveBtn = createPrimaryButton('保存する')
+
+    saveBtn.addEventListener('click', async () => {
+      const key = input.value.trim()
+      errorText.textContent = ''
+
+      if (!key) {
+        errorText.textContent = 'APIキーを入力してください'
+        return
+      }
+      if (key.startsWith('sk_live_')) {
+        errorText.textContent = '⚠️ 本番環境のAPIキーは使用できません'
+        return
+      }
+      if (!key.startsWith('sk_test_')) {
+        errorText.textContent = '有効なテスト用APIキー（sk_test_）を入力してください'
+        return
+      }
+
+      // ローディング
+      const originalText = saveBtn.textContent
+      saveBtn.textContent = '保存中...'
+      saveBtn.disabled = true
+
+      const res = await sendMessage({ action: 'SAVE_API_KEY', payload: { plainKey: key } })
+
+      if (!res.ok) {
+        errorText.textContent = res.error
+        saveBtn.textContent = originalText
+        saveBtn.disabled = false
+        return
+      }
+
+      navigate('S02')
+    })
+
+    // Enterキーでも保存
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') saveBtn.click()
+    })
+
+    card.appendChild(cardTitle)
+    card.appendChild(cardDesc)
+    card.appendChild(inputWrap)
+    card.appendChild(errorText)
+    card.appendChild(saveBtn)
+    body.appendChild(card)
+    container.appendChild(body)
+
+    // フォーカス
+    requestAnimationFrame(() => input.focus())
+
+    return container
+  },
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}
+
+function createPrimaryButton(text: string): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.textContent = text
+  btn.style.cssText = `
+    width: 100%;
+    padding: 11px;
+    background: #635bff;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => { if (!btn.disabled) btn.style.background = '#4f46e5' })
+  btn.addEventListener('mouseleave', () => { if (!btn.disabled) btn.style.background = '#635bff' })
+  return btn
+}

--- a/src/popup/screens/s02-search.ts
+++ b/src/popup/screens/s02-search.ts
@@ -1,0 +1,283 @@
+// S02: 顧客検索画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import type { StripeCustomer } from '../../types/stripe'
+import { sendMessage } from '../send-message'
+import { createLoadingSpinner } from '../components/loading-spinner'
+
+export const s02Search: Screen = {
+  render(_state: AppState, navigate: NavigateFn): HTMLElement {
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    const headerLeft = div(`display: flex; align-items: center; gap: 10px;`)
+    const logo = div(`
+      width: 28px;
+      height: 28px;
+      background: #635bff;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 14px;
+      font-weight: 700;
+      flex-shrink: 0;
+    `)
+    logo.textContent = 'S'
+    const title = el('span', '顧客検索', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `)
+    headerLeft.appendChild(logo)
+    headerLeft.appendChild(title)
+
+    // APIキー設定ボタン（歯車）
+    const settingsBtn = document.createElement('button')
+    settingsBtn.textContent = '⚙️'
+    settingsBtn.title = 'APIキー設定'
+    settingsBtn.style.cssText = `
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 18px;
+      opacity: 0.6;
+      padding: 4px;
+      border-radius: 4px;
+      line-height: 1;
+      transition: opacity 0.15s;
+    `
+    settingsBtn.addEventListener('mouseenter', () => { settingsBtn.style.opacity = '1' })
+    settingsBtn.addEventListener('mouseleave', () => { settingsBtn.style.opacity = '0.6' })
+    settingsBtn.addEventListener('click', () => navigate('S01'))
+
+    header.appendChild(headerLeft)
+    header.appendChild(settingsBtn)
+    container.appendChild(header)
+
+    // ── 検索フォーム ──
+    const searchArea = div(`
+      padding: 16px 20px;
+      background: #fff;
+      border-bottom: 1px solid #e5e7eb;
+      flex-shrink: 0;
+    `)
+    const inputRow = div(`display: flex; gap: 8px;`)
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.placeholder = 'team_id を入力...'
+    input.autocomplete = 'off'
+    input.spellcheck = false
+    input.style.cssText = `
+      flex: 1;
+      padding: 9px 12px;
+      border: 1.5px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 13px;
+      color: #1a1a2e;
+      background: #f9fafb;
+      outline: none;
+      transition: border-color 0.15s;
+    `
+    input.addEventListener('focus', () => { input.style.borderColor = '#635bff' })
+    input.addEventListener('blur', () => { input.style.borderColor = '#e5e7eb' })
+
+    const searchBtn = document.createElement('button')
+    searchBtn.textContent = '検索'
+    searchBtn.style.cssText = `
+      padding: 9px 18px;
+      background: #635bff;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.15s;
+    `
+    searchBtn.addEventListener('mouseenter', () => { if (!searchBtn.disabled) searchBtn.style.background = '#4f46e5' })
+    searchBtn.addEventListener('mouseleave', () => { if (!searchBtn.disabled) searchBtn.style.background = '#635bff' })
+
+    inputRow.appendChild(input)
+    inputRow.appendChild(searchBtn)
+    searchArea.appendChild(inputRow)
+    container.appendChild(searchArea)
+
+    // ── 結果エリア ──
+    const resultArea = div(`
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    `)
+    container.appendChild(resultArea)
+
+    // 検索実行
+    const doSearch = async () => {
+      const teamId = input.value.trim()
+      if (!teamId) {
+        showMessage(resultArea, '⚠️', 'team_id を入力してください', '#9ca3af')
+        return
+      }
+
+      // ローディング
+      resultArea.replaceChildren(createLoadingSpinner('検索中...'))
+      searchBtn.disabled = true
+
+      const res = await sendMessage<{ customers: StripeCustomer[] }>({
+        action: 'SEARCH_CUSTOMER',
+        payload: { teamId },
+      })
+
+      searchBtn.disabled = false
+
+      if (!res.ok) {
+        showMessage(resultArea, '⚠️', res.error, '#dc2626')
+        return
+      }
+
+      const { customers } = res.data
+      if (customers.length === 0) {
+        showMessage(resultArea, '🔍', `team_id "${teamId}" の顧客が見つかりませんでした`, '#6b7280')
+        return
+      }
+
+      renderResults(resultArea, customers, navigate)
+    }
+
+    searchBtn.addEventListener('click', doSearch)
+    input.addEventListener('keydown', (e) => { if (e.key === 'Enter') doSearch() })
+
+    // 初期メッセージ
+    showMessage(resultArea, '🔍', 'team_id で顧客を検索できます', '#9ca3af')
+
+    requestAnimationFrame(() => input.focus())
+
+    return container
+  },
+}
+
+function renderResults(
+  area: HTMLElement,
+  customers: StripeCustomer[],
+  navigate: NavigateFn
+): void {
+  area.replaceChildren()
+
+  const count = el('p', `${customers.length} 件見つかりました`, `
+    font-size: 12px;
+    color: #6b7280;
+    margin-bottom: 10px;
+  `)
+  area.appendChild(count)
+
+  for (const customer of customers) {
+    const item = div(`
+      background: #fff;
+      border-radius: 10px;
+      padding: 14px 16px;
+      margin-bottom: 8px;
+      cursor: pointer;
+      border: 1.5px solid #e5e7eb;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    `)
+    item.addEventListener('mouseenter', () => {
+      item.style.borderColor = '#635bff'
+      item.style.boxShadow = '0 2px 8px rgba(99,91,255,0.12)'
+    })
+    item.addEventListener('mouseleave', () => {
+      item.style.borderColor = '#e5e7eb'
+      item.style.boxShadow = 'none'
+    })
+
+    const name = el('p', customer.name ?? '(名前なし)', `
+      font-size: 14px;
+      font-weight: 600;
+      color: #1a1a2e;
+      margin-bottom: 4px;
+    `)
+    const email = el('p', customer.email ?? '(メールなし)', `
+      font-size: 12px;
+      color: #6b7280;
+      margin-bottom: 4px;
+    `)
+    const idEl = el('p', customer.id, `
+      font-size: 11px;
+      color: #9ca3af;
+      font-family: monospace;
+    `)
+
+    item.appendChild(name)
+    item.appendChild(email)
+    if (customer.description) {
+      const desc = el('p', customer.description, `
+        font-size: 12px;
+        color: #6b7280;
+        margin-top: 4px;
+        margin-bottom: 4px;
+        line-height: 1.4;
+        word-break: break-all;
+      `)
+      item.appendChild(desc)
+    }
+    item.appendChild(idEl)
+    item.addEventListener('click', () => {
+      navigate('S03', { customer })
+    })
+    area.appendChild(item)
+  }
+}
+
+function showMessage(area: HTMLElement, icon: string, message: string, color: string): void {
+  area.replaceChildren()
+  const wrap = div(`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    text-align: center;
+    padding: 20px;
+    gap: 12px;
+  `)
+  const iconEl = el('p', icon, `font-size: 32px; line-height: 1;`)
+  const msgEl = el('p', message, `font-size: 13px; color: ${color}; line-height: 1.5;`)
+  wrap.appendChild(iconEl)
+  wrap.appendChild(msgEl)
+  area.appendChild(wrap)
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}

--- a/src/popup/screens/s03-menu.ts
+++ b/src/popup/screens/s03-menu.ts
@@ -1,0 +1,247 @@
+// S03: 操作メニュー画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+
+export const s03Menu: Screen = {
+  render(state: AppState, navigate: NavigateFn): HTMLElement {
+    const customer = state.customer
+
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    const backBtn = document.createElement('button')
+    backBtn.textContent = '←'
+    backBtn.title = '戻る'
+    backBtn.style.cssText = `
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 20px;
+      color: #6b7280;
+      padding: 2px 6px 2px 0;
+      line-height: 1;
+      transition: color 0.15s;
+    `
+    backBtn.addEventListener('mouseenter', () => { backBtn.style.color = '#1a1a2e' })
+    backBtn.addEventListener('mouseleave', () => { backBtn.style.color = '#6b7280' })
+    backBtn.addEventListener('click', () => navigate('S02'))
+
+    const headerTitle = el('h1', '操作メニュー', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `)
+    header.appendChild(backBtn)
+    header.appendChild(headerTitle)
+    container.appendChild(header)
+
+    // ── 顧客情報カード ──
+    const infoSection = div(`padding: 16px 20px; flex-shrink: 0;`)
+    const infoCard = div(`
+      background: #fff;
+      border-radius: 10px;
+      padding: 16px;
+      border: 1px solid #e5e7eb;
+    `)
+
+    const infoLabel = el('p', '選択中の顧客', `
+      font-size: 11px;
+      font-weight: 600;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 8px;
+    `)
+
+    const customerName = el('p', customer?.name ?? '(名前なし)', `
+      font-size: 16px;
+      font-weight: 700;
+      color: #1a1a2e;
+      margin-bottom: 4px;
+    `)
+
+    const customerEmail = el('p', customer?.email ?? '(メールなし)', `
+      font-size: 13px;
+      color: #6b7280;
+      margin-bottom: 6px;
+    `)
+
+    const customerId = el('p', customer?.id ?? '', `
+      font-size: 11px;
+      color: #9ca3af;
+      font-family: monospace;
+    `)
+
+    infoCard.appendChild(infoLabel)
+    infoCard.appendChild(customerName)
+    infoCard.appendChild(customerEmail)
+
+    if (customer?.description) {
+      const customerDesc = el('p', customer.description, `
+        font-size: 12px;
+        color: #6b7280;
+        margin-top: 6px;
+        margin-bottom: 2px;
+        line-height: 1.4;
+        word-break: break-all;
+      `)
+      infoCard.appendChild(customerDesc)
+    }
+
+    infoCard.appendChild(customerId)
+    infoSection.appendChild(infoCard)
+    container.appendChild(infoSection)
+
+    // ── 操作ボタン ──
+    const actionsSection = div(`
+      flex: 1;
+      padding: 4px 20px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    `)
+
+    const sectionLabel = el('p', '実行する操作を選択', `
+      font-size: 11px;
+      font-weight: 600;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 4px;
+    `)
+    actionsSection.appendChild(sectionLabel)
+
+    // サブスクリプション管理ボタン
+    const subscriptionBtn = createActionButton(
+      '📋',
+      'サブスクリプション管理',
+      'サブスクのキャンセルができます',
+      '#635bff'
+    )
+    subscriptionBtn.addEventListener('click', () => {
+      navigate('S04', { subscriptions: undefined, selectedSubscription: undefined })
+    })
+
+    // 現金残高追加ボタン
+    const balanceBtn = createActionButton(
+      '💴',
+      '現金残高を追加',
+      'テスト用の現金残高をチャージします',
+      '#059669'
+    )
+    balanceBtn.addEventListener('click', () => {
+      navigate('S06', { invoices: undefined, selectedInvoice: undefined, cashAmount: undefined })
+    })
+
+    actionsSection.appendChild(subscriptionBtn)
+    actionsSection.appendChild(balanceBtn)
+    container.appendChild(actionsSection)
+
+    return container
+  },
+}
+
+function createActionButton(
+  icon: string,
+  label: string,
+  description: string,
+  accentColor: string
+): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.style.cssText = `
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+    padding: 16px;
+    background: #fff;
+    border: 1.5px solid #e5e7eb;
+    border-radius: 10px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s, box-shadow 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => {
+    btn.style.borderColor = accentColor
+    btn.style.boxShadow = `0 2px 8px rgba(0,0,0,0.08)`
+  })
+  btn.addEventListener('mouseleave', () => {
+    btn.style.borderColor = '#e5e7eb'
+    btn.style.boxShadow = 'none'
+  })
+
+  const iconEl = div(`
+    width: 40px;
+    height: 40px;
+    background: ${accentColor}1a;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+    flex-shrink: 0;
+  `)
+  iconEl.textContent = icon
+
+  const textWrap = div(`flex: 1;`)
+  const labelEl = el('p', label, `
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a2e;
+    margin-bottom: 3px;
+  `)
+  const descEl = el('p', description, `
+    font-size: 12px;
+    color: #6b7280;
+    line-height: 1.4;
+  `)
+  textWrap.appendChild(labelEl)
+  textWrap.appendChild(descEl)
+
+  const arrow = el('span', '›', `
+    font-size: 20px;
+    color: #9ca3af;
+    flex-shrink: 0;
+    line-height: 1;
+  `)
+
+  btn.appendChild(iconEl)
+  btn.appendChild(textWrap)
+  btn.appendChild(arrow)
+
+  return btn
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}

--- a/src/popup/send-message.ts
+++ b/src/popup/send-message.ts
@@ -1,0 +1,21 @@
+/// <reference types="chrome" />
+
+import type { RequestMessage, ResponseMessage } from '../types/messages'
+
+/**
+ * Service Worker にメッセージを送信する
+ */
+export async function sendMessage<T = unknown>(message: RequestMessage): Promise<ResponseMessage<T>> {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(message, (response: ResponseMessage<T>) => {
+      if (chrome.runtime.lastError) {
+        resolve({
+          ok: false,
+          error: chrome.runtime.lastError.message || 'メッセージ送信に失敗しました',
+        })
+        return
+      }
+      resolve(response)
+    })
+  })
+}

--- a/src/types/stripe.ts
+++ b/src/types/stripe.ts
@@ -5,6 +5,7 @@ export interface StripeCustomer {
   object: 'customer'
   email: string | null
   name: string | null
+  description: string | null
   metadata: Record<string, string>
   created: number
   currency: string | null


### PR DESCRIPTION
## Summary
- S01: APIキー設定画面（バリデーション・保存・表示トグル）
- S02: 顧客検索画面（team_id検索・結果一覧・description表示）
- S03: 操作メニュー画面（顧客情報・description表示・2つの操作ボタン）
- `sendMessage` を独立ファイルに切り出し（循環参照回避）
- `StripeCustomer` に `description` フィールドを追加

## Test plan
- [x] S01: `sk_live_` 入力時に警告表示・保存ブロック確認済み
- [x] S02: 検索結果に description が表示されることを確認済み
- [x] S03: 顧客情報カードに description が表示されることを確認済み
- [x] 動作確認済み

Closes #6 (partial: S01〜S03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)