### PR TITLE
feat: Step 6 (S04〜S05) - サブスクリプション一覧・キャンセル確認画面

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -64,7 +64,7 @@ async function stripeRequest<T>(
     let url = `${STRIPE_API_BASE}${path}`
     const headers: Record<string, string> = {
       Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
+      'Stripe-Version': '2020-08-27',
     }
 
     let body: string | undefined
@@ -73,11 +73,16 @@ async function stripeRequest<T>(
       const queryString = new URLSearchParams(params).toString()
       url += `?${queryString}`
     } else if ((method === 'POST' || method === 'DELETE') && params) {
-      body = new URLSearchParams(params).toString()
+      const bodyStr = new URLSearchParams(params).toString()
+      if (bodyStr) {
+        body = bodyStr
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+      }
     }
 
     // API リクエスト実行
-    const response = await fetch(url, { method, headers, body })
+    // credentials: 'omit' でブラウザのセッションクッキーを除外する
+    const response = await fetch(url, { method, headers, body, credentials: 'omit' })
 
     // エラーハンドリング
     if (!response.ok) {
@@ -89,6 +94,15 @@ async function stripeRequest<T>(
           ok: false,
           error: 'APIキーが無効です。再設定してください。',
           code: 'API_KEY_INVALID',
+        }
+      }
+
+      // レートリミット
+      if (response.status === 429) {
+        return {
+          ok: false,
+          error: 'リクエストが多すぎます。少し待ってから再試行してください。',
+          code: 'RATE_LIMIT',
         }
       }
 
@@ -279,6 +293,13 @@ async function handleListSubscriptions(
 /**
  * サブスクリプションキャンセル
  * DELETE /v1/subscriptions/{subscriptionId}
+ *
+ * TODO: Chrome拡張機能のService Workerからfetchすると Chrome が自動付与する
+ *   `Origin: chrome-extension://{extension_id}` ヘッダーを Cloudflare がブロックし、
+ *   Stripe のバックエンドに到達する前に HTTP 429 が返される。
+ *   GETリクエストは通過するが、DELETEなどの書き込み操作のみブロックされることを確認済み。
+ *   対策: 社内プロキシ（例: stg.form.run の Rails エンドポイント）経由でキャンセルを
+ *   実行するよう変更することで回避できる。
  */
 async function handleCancelSubscription(
   subscriptionId: string

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -9,6 +9,8 @@ import { sendMessage } from './send-message'
 import { s01ApiKey } from './screens/s01-api-key'
 import { s02Search } from './screens/s02-search'
 import { s03Menu } from './screens/s03-menu'
+import { s04Subscriptions } from './screens/s04-subscriptions'
+import { s05CancelConfirm } from './screens/s05-cancel-confirm'
 
 // アプリケーション状態
 const appState: AppState = {}
@@ -18,8 +20,8 @@ const screens: Record<ScreenId, Screen> = {
   S01: s01ApiKey,
   S02: s02Search,
   S03: s03Menu,
-  S04: createPlaceholderScreen('S04', 'サブスクリプション一覧'),
-  S05: createPlaceholderScreen('S05', 'キャンセル確認'),
+  S04: s04Subscriptions,
+  S05: s05CancelConfirm,
   S06: createPlaceholderScreen('S06', 'Invoice一覧'),
   S07: createPlaceholderScreen('S07', '残高追加確認'),
 }

--- a/src/popup/screens/s04-subscriptions.ts
+++ b/src/popup/screens/s04-subscriptions.ts
@@ -1,0 +1,329 @@
+// S04: サブスクリプション一覧画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import type { StripeSubscription, StripeSubscriptionStatus } from '../../types/stripe'
+import { sendMessage } from '../send-message'
+import { createLoadingSpinner } from '../components/loading-spinner'
+
+// 重複fetchを防ぐフラグ
+let isFetching = false
+
+export const s04Subscriptions: Screen = {
+  render(state: AppState, navigate: NavigateFn): HTMLElement {
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    const backBtn = createBackButton(() => navigate('S03'))
+    const headerTitle = el('h1', 'サブスクリプション', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `)
+    header.appendChild(backBtn)
+    header.appendChild(headerTitle)
+    container.appendChild(header)
+
+    // ── 顧客名サブヘッダー ──
+    const subHeader = div(`
+      padding: 10px 20px;
+      background: #fff;
+      border-bottom: 1px solid #e5e7eb;
+      flex-shrink: 0;
+    `)
+    subHeader.appendChild(el('p', state.customer?.name ?? state.customer?.email ?? '', `
+      font-size: 12px;
+      color: #6b7280;
+    `))
+    container.appendChild(subHeader)
+
+    // ── リストエリア ──
+    const listArea = div(`
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    `)
+    container.appendChild(listArea)
+
+    // データ取得済みなら即表示、なければ fetch
+    if (state.subscriptions) {
+      renderList(listArea, state.subscriptions, navigate)
+    } else {
+      fetchAndRender(listArea, state, navigate)
+    }
+
+    return container
+  },
+}
+
+async function fetchAndRender(
+  area: HTMLElement,
+  state: AppState,
+  navigate: NavigateFn
+): Promise<void> {
+  if (isFetching) return
+  const customerId = state.customer?.id
+  if (!customerId) {
+    showMessage(area, '⚠️', '顧客情報がありません', '#dc2626')
+    return
+  }
+
+  isFetching = true
+  area.replaceChildren(createLoadingSpinner('読み込み中...'))
+
+  const res = await sendMessage<{ subscriptions: StripeSubscription[] }>({
+    action: 'LIST_SUBSCRIPTIONS',
+    payload: { customerId },
+  })
+
+  isFetching = false
+
+  if (!res.ok) {
+    showMessage(area, '⚠️', res.error, '#dc2626')
+    return
+  }
+
+  // stateに保存して再描画
+  navigate('S04', { subscriptions: res.data.subscriptions })
+}
+
+function renderList(
+  area: HTMLElement,
+  subscriptions: StripeSubscription[],
+  navigate: NavigateFn
+): void {
+  area.replaceChildren()
+
+  if (subscriptions.length === 0) {
+    showMessage(area, '📋', 'サブスクリプションがありません', '#6b7280')
+    return
+  }
+
+  const count = el('p', `${subscriptions.length} 件`, `
+    font-size: 12px;
+    color: #6b7280;
+    margin-bottom: 10px;
+  `)
+  area.appendChild(count)
+
+  for (const sub of subscriptions) {
+    area.appendChild(createSubscriptionCard(sub, navigate))
+  }
+}
+
+function createSubscriptionCard(sub: StripeSubscription, navigate: NavigateFn): HTMLElement {
+  const isCanceled = sub.status === 'canceled'
+
+  const card = div(`
+    background: #fff;
+    border-radius: 10px;
+    padding: 14px 16px;
+    margin-bottom: 8px;
+    border: 1.5px solid #e5e7eb;
+    cursor: ${isCanceled ? 'default' : 'pointer'};
+    opacity: ${isCanceled ? '0.6' : '1'};
+    transition: border-color 0.15s, box-shadow 0.15s;
+  `)
+
+  if (!isCanceled) {
+    card.addEventListener('mouseenter', () => {
+      card.style.borderColor = '#635bff'
+      card.style.boxShadow = '0 2px 8px rgba(99,91,255,0.12)'
+    })
+    card.addEventListener('mouseleave', () => {
+      card.style.borderColor = '#e5e7eb'
+      card.style.boxShadow = 'none'
+    })
+    card.addEventListener('click', () => navigate('S05', { selectedSubscription: sub }))
+  }
+
+  // ── 1行目: ステータスバッジ + プラン名 ──
+  const row1 = div(`display: flex; align-items: center; gap: 8px; margin-bottom: 8px;`)
+  row1.appendChild(createStatusBadge(sub.status))
+
+  const planName = el('p', getPlanName(sub), `
+    font-size: 13px;
+    font-weight: 600;
+    color: #1a1a2e;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `)
+  row1.appendChild(planName)
+
+  // ── 2行目: 金額 + 期間 ──
+  const row2 = div(`display: flex; justify-content: space-between; align-items: center;`)
+
+  const amount = el('p', formatAmount(sub), `
+    font-size: 13px;
+    font-weight: 500;
+    color: #374151;
+  `)
+
+  const period = el('p', formatPeriod(sub), `
+    font-size: 11px;
+    color: #9ca3af;
+  `)
+
+  row2.appendChild(amount)
+  row2.appendChild(period)
+
+  card.appendChild(row1)
+  card.appendChild(row2)
+
+  // キャンセル済みの場合は選択不可の注記
+  if (isCanceled) {
+    const note = el('p', 'キャンセル済みのため操作できません', `
+      font-size: 11px;
+      color: #9ca3af;
+      margin-top: 6px;
+    `)
+    card.appendChild(note)
+  }
+
+  return card
+}
+
+function createStatusBadge(status: StripeSubscriptionStatus): HTMLElement {
+  const map: Record<StripeSubscriptionStatus, { label: string; bg: string; color: string }> = {
+    active:             { label: '有効',           bg: '#d1fae5', color: '#065f46' },
+    canceled:           { label: 'キャンセル済み', bg: '#f3f4f6', color: '#6b7280' },
+    incomplete:         { label: '未完了',         bg: '#fef3c7', color: '#92400e' },
+    incomplete_expired: { label: '期限切れ',       bg: '#fee2e2', color: '#991b1b' },
+    past_due:           { label: '支払い遅延',     bg: '#fee2e2', color: '#991b1b' },
+    paused:             { label: '一時停止',       bg: '#ede9fe', color: '#5b21b6' },
+    trialing:           { label: 'トライアル',     bg: '#dbeafe', color: '#1e40af' },
+    unpaid:             { label: '未払い',         bg: '#fee2e2', color: '#991b1b' },
+  }
+  const { label, bg, color } = map[status] ?? { label: status, bg: '#f3f4f6', color: '#6b7280' }
+
+  const badge = el('span', label, `
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: ${bg};
+    color: ${color};
+    white-space: nowrap;
+    flex-shrink: 0;
+  `)
+  return badge
+}
+
+function getPlanName(sub: StripeSubscription): string {
+  const item = sub.items.data[0]
+  if (!item) return '(プランなし)'
+  const product = item.price.product
+  if (typeof product === 'object') return product.name
+  return item.price.id
+}
+
+function formatAmount(sub: StripeSubscription): string {
+  const item = sub.items.data[0]
+  if (!item) return '-'
+  const { unit_amount, currency, recurring } = item.price
+  if (unit_amount === null) return '-'
+
+  const formatted = new Intl.NumberFormat('ja-JP', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: 0,
+  }).format(unit_amount)
+
+  if (!recurring) return formatted
+
+  const intervalMap: Record<string, string> = {
+    day: '日', week: '週', month: '月', year: '年',
+  }
+  const intervalLabel = intervalMap[recurring.interval] ?? recurring.interval
+  const count = recurring.interval_count
+  return `${formatted} / ${count > 1 ? `${count}${intervalLabel}` : intervalLabel}`
+}
+
+function formatPeriod(sub: StripeSubscription): string {
+  const fmt = (ts: number | null | undefined): string => {
+    if (!ts) return '-'
+    const d = new Date(ts * 1000)
+    if (isNaN(d.getTime())) return '-'
+    return d.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })
+  }
+
+  if (sub.status === 'canceled' && sub.canceled_at) {
+    return `${fmt(sub.canceled_at)} キャンセル`
+  }
+  const start = fmt(sub.current_period_start)
+  const end = fmt(sub.current_period_end)
+  if (start === '-' && end === '-') return '-'
+  return `${start} 〜 ${end}`
+}
+
+function showMessage(area: HTMLElement, icon: string, message: string, color: string): void {
+  area.replaceChildren()
+  const wrap = div(`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    text-align: center;
+    padding: 20px;
+    gap: 12px;
+  `)
+  wrap.appendChild(el('p', icon, `font-size: 32px; line-height: 1;`))
+  wrap.appendChild(el('p', message, `font-size: 13px; color: ${color}; line-height: 1.5;`))
+  area.appendChild(wrap)
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}
+
+function createBackButton(onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.textContent = '←'
+  btn.style.cssText = `
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: #6b7280;
+    padding: 2px 6px 2px 0;
+    line-height: 1;
+    transition: color 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => { btn.style.color = '#1a1a2e' })
+  btn.addEventListener('mouseleave', () => { btn.style.color = '#6b7280' })
+  btn.addEventListener('click', onClick)
+  return btn
+}

--- a/src/popup/screens/s05-cancel-confirm.ts
+++ b/src/popup/screens/s05-cancel-confirm.ts
@@ -1,0 +1,335 @@
+// S05: サブスクリプション キャンセル確認画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import { sendMessage } from '../send-message'
+
+export const s05CancelConfirm: Screen = {
+  render(state: AppState, navigate: NavigateFn): HTMLElement {
+    const sub = state.selectedSubscription
+
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    const backBtn = createBackButton(() => navigate('S04'))
+    const headerTitle = el('h1', 'キャンセル確認', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `)
+    header.appendChild(backBtn)
+    header.appendChild(headerTitle)
+    container.appendChild(header)
+
+    // ── 本文 ──
+    const body = div(`
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      padding: 20px;
+      gap: 16px;
+      overflow-y: auto;
+    `)
+
+    // 警告バナー
+    const warning = div(`
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      border-radius: 10px;
+      padding: 14px;
+    `)
+    const warnIcon = el('span', '⚠️', `font-size: 18px; line-height: 1.3; flex-shrink: 0;`)
+    const warnText = el('p', 'この操作は取り消せません。サブスクリプションを即座にキャンセルします。', `
+      font-size: 13px;
+      color: #991b1b;
+      line-height: 1.5;
+    `)
+    warning.appendChild(warnIcon)
+    warning.appendChild(warnText)
+    body.appendChild(warning)
+
+    // ── サブスク詳細カード ──
+    const card = div(`
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid #e5e7eb;
+      overflow: hidden;
+    `)
+
+    const cardTitle = el('p', 'キャンセル対象', `
+      font-size: 11px;
+      font-weight: 600;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 12px 16px 8px;
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+    `)
+    card.appendChild(cardTitle)
+
+    const rows: [string, string][] = [
+      ['プラン',       getPlanName(sub)],
+      ['ステータス',   getStatusLabel(sub?.status)],
+      ['金額',         formatAmount(sub)],
+      ['現在の期間',   formatPeriod(sub)],
+      ['サブスクID',   sub?.id ?? '-'],
+    ]
+
+    for (const [label, value] of rows) {
+      const row = div(`
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 10px 16px;
+        border-bottom: 1px solid #f3f4f6;
+      `)
+      const labelEl = el('span', label, `
+        font-size: 12px;
+        color: #6b7280;
+        flex-shrink: 0;
+      `)
+      const valueEl = el('span', value, `
+        font-size: 12px;
+        font-weight: 500;
+        color: #1a1a2e;
+        text-align: right;
+        word-break: break-all;
+        font-family: ${label === 'サブスクID' ? 'monospace' : 'inherit'};
+      `)
+      row.appendChild(labelEl)
+      row.appendChild(valueEl)
+      card.appendChild(row)
+    }
+
+    body.appendChild(card)
+
+    // ── スペーサー ──
+    const spacer = div(`flex: 1;`)
+    body.appendChild(spacer)
+
+    // ── ボタンエリア ──
+    const btnArea = div(`display: flex; flex-direction: column; gap: 10px;`)
+
+    // エラーメッセージ
+    const errorText = el('p', '', `
+      font-size: 12px;
+      color: #dc2626;
+      text-align: center;
+      min-height: 16px;
+      line-height: 1.4;
+    `)
+    btnArea.appendChild(errorText)
+
+    // キャンセルボタン（赤）
+    const cancelBtn = document.createElement('button')
+    cancelBtn.textContent = 'キャンセルする'
+    cancelBtn.style.cssText = `
+      width: 100%;
+      padding: 12px;
+      background: #dc2626;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s;
+    `
+    cancelBtn.addEventListener('mouseenter', () => { if (!cancelBtn.disabled) cancelBtn.style.background = '#b91c1c' })
+    cancelBtn.addEventListener('mouseleave', () => { if (!cancelBtn.disabled) cancelBtn.style.background = '#dc2626' })
+
+    cancelBtn.addEventListener('click', async () => {
+      if (!sub) return
+      errorText.textContent = ''
+      cancelBtn.textContent = 'キャンセル中...'
+      cancelBtn.disabled = true
+      cancelBtn.style.background = '#9ca3af'
+
+      const res = await sendMessage({
+        action: 'CANCEL_SUBSCRIPTION',
+        payload: { subscriptionId: sub.id },
+      })
+
+      if (!res.ok) {
+        errorText.textContent = res.error
+        cancelBtn.textContent = 'キャンセルする'
+        cancelBtn.disabled = false
+        cancelBtn.style.background = '#dc2626'
+        return
+      }
+
+      // 成功 → S04に戻る（subscriptionsをリセットして再取得させる）
+      navigate('S03', { subscriptions: undefined, selectedSubscription: undefined })
+      showSuccessToast()
+    })
+
+    // 戻るボタン
+    const backBtnBottom = document.createElement('button')
+    backBtnBottom.textContent = '戻る'
+    backBtnBottom.style.cssText = `
+      width: 100%;
+      padding: 11px;
+      background: #fff;
+      color: #374151;
+      border: 1.5px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s;
+    `
+    backBtnBottom.addEventListener('mouseenter', () => { backBtnBottom.style.background = '#f9fafb' })
+    backBtnBottom.addEventListener('mouseleave', () => { backBtnBottom.style.background = '#fff' })
+    backBtnBottom.addEventListener('click', () => navigate('S04'))
+
+    btnArea.appendChild(cancelBtn)
+    btnArea.appendChild(backBtnBottom)
+    body.appendChild(btnArea)
+    container.appendChild(body)
+
+    return container
+  },
+}
+
+function showSuccessToast(): void {
+  const toast = document.createElement('div')
+  toast.textContent = '✅ キャンセルしました'
+  toast.style.cssText = `
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #065f46;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    z-index: 9999;
+    white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    animation: fadeIn 0.2s ease;
+  `
+
+  // アニメーション
+  if (!document.getElementById('toast-style')) {
+    const style = document.createElement('style')
+    style.id = 'toast-style'
+    style.textContent = `@keyframes fadeIn { from { opacity: 0; transform: translateX(-50%) translateY(8px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }`
+    document.head.appendChild(style)
+  }
+
+  document.body.appendChild(toast)
+  setTimeout(() => toast.remove(), 2500)
+}
+
+// ── ヘルパー ──
+
+function getPlanName(sub: AppState['selectedSubscription']): string {
+  if (!sub) return '-'
+  const item = sub.items.data[0]
+  if (!item) return '(プランなし)'
+  const product = item.price.product
+  if (typeof product === 'object') return product.name
+  return item.price.id
+}
+
+function getStatusLabel(status: string | undefined): string {
+  const map: Record<string, string> = {
+    active: '有効', canceled: 'キャンセル済み', incomplete: '未完了',
+    incomplete_expired: '期限切れ', past_due: '支払い遅延',
+    paused: '一時停止', trialing: 'トライアル', unpaid: '未払い',
+  }
+  return status ? (map[status] ?? status) : '-'
+}
+
+function formatAmount(sub: AppState['selectedSubscription']): string {
+  if (!sub) return '-'
+  const item = sub.items.data[0]
+  if (!item) return '-'
+  const { unit_amount, currency, recurring } = item.price
+  if (unit_amount === null) return '-'
+
+  const formatted = new Intl.NumberFormat('ja-JP', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+    maximumFractionDigits: 0,
+  }).format(unit_amount)
+
+  if (!recurring) return formatted
+  const intervalMap: Record<string, string> = { day: '日', week: '週', month: '月', year: '年' }
+  const intervalLabel = intervalMap[recurring.interval] ?? recurring.interval
+  const count = recurring.interval_count
+  return `${formatted} / ${count > 1 ? `${count}${intervalLabel}` : intervalLabel}`
+}
+
+function formatPeriod(sub: AppState['selectedSubscription']): string {
+  if (!sub) return '-'
+  const fmt = (ts: number | null | undefined): string => {
+    if (!ts) return '-'
+    const d = new Date(ts * 1000)
+    if (isNaN(d.getTime())) return '-'
+    return d.toLocaleDateString('ja-JP', { year: 'numeric', month: 'numeric', day: 'numeric' })
+  }
+  const start = fmt(sub.current_period_start)
+  const end = fmt(sub.current_period_end)
+  if (start === '-' && end === '-') return '-'
+  return `${start} 〜 ${end}`
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}
+
+function createBackButton(onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.textContent = '←'
+  btn.style.cssText = `
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: #6b7280;
+    padding: 2px 6px 2px 0;
+    line-height: 1;
+    transition: color 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => { btn.style.color = '#1a1a2e' })
+  btn.addEventListener('mouseleave', () => { btn.style.color = '#6b7280' })
+  btn.addEventListener('click', onClick)
+  return btn
+}

--- a/src/types/stripe.ts
+++ b/src/types/stripe.ts
@@ -28,8 +28,8 @@ export interface StripeSubscription {
   items: {
     data: StripeSubscriptionItem[]
   }
-  current_period_start: number
-  current_period_end: number
+  current_period_start: number | null
+  current_period_end: number | null
   created: number
   cancel_at_period_end: boolean
   canceled_at: number | null


### PR DESCRIPTION
## Summary
- S04: サブスクリプション一覧（ステータスバッジ・プラン名・金額・期間、重複fetch防止）
- S05: キャンセル確認（詳細カード・赤いキャンセルボタン・成功トースト）
- SW: `Stripe-Version: 2020-08-27` ヘッダー追加、429の日本語メッセージ化
- `StripeSubscription.current_period_start/end` を `number | null` に修正

## 既知の問題
Chrome拡張機能のService Workerから送信されるfetchリクエストにChromeが自動付与する `Origin: chrome-extension://` ヘッダーをCloudflareがブロックし、DELETEリクエストが HTTP 429 で失敗する。GETは通過するが書き込み操作のみブロックされる。
対策はservice-worker.tsのTODOコメントに記載済み。

## Test plan
- [x] S03 → S04: サブスクリプション一覧が表示される
- [x] キャンセル済みサブスクがグレーアウトで選択不可
- [x] S04 → S05: 詳細確認画面に遷移する
- [x] S05: 赤いキャンセルボタンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)