### PR TITLE
fix: コンテントスクリプト経由でStripe書き込みAPIのCloudflareブロックを回避

### DIFF
--- a/build.js
+++ b/build.js
@@ -30,6 +30,7 @@ async function build() {
   const entryPoints = [
     { in: 'src/popup/popup.ts', out: 'dist/popup' },
     { in: 'src/background/service-worker.ts', out: 'dist/service-worker' },
+    { in: 'src/content/stripe-proxy.ts', out: 'dist/content-script' },
   ]
 
   if (isWatch) {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -291,20 +291,58 @@ async function handleListSubscriptions(
 }
 
 /**
+ * コンテントスクリプト経由でStripe APIに書き込みリクエストを送信
+ * stg.form.run ページの Origin (https://stg.form.run) を使うため
+ * chrome-extension:// Origin をブロックする Cloudflare のルールを回避できる
+ */
+async function proxyRequest<T>(
+  method: 'DELETE' | 'POST',
+  path: string,
+  params?: Record<string, string>
+): Promise<ResponseMessage<T>> {
+  const apiKey = await loadApiKey()
+  if (!apiKey) {
+    return { ok: false, error: 'APIキーが設定されていません', code: 'API_KEY_NOT_FOUND' }
+  }
+
+  // stg.form.run のタブを探す
+  const tabs = await chrome.tabs.query({ url: 'https://stg.form.run/*' })
+  const tabId = tabs[0]?.id
+  if (!tabId) {
+    return {
+      ok: false,
+      error: 'stg.form.run のタブが見つかりません。stg.form.run を開いてから再試行してください。',
+      code: 'PROXY_TAB_NOT_FOUND',
+    }
+  }
+
+  try {
+    const response = await chrome.tabs.sendMessage(tabId, {
+      action: 'STRIPE_PROXY',
+      method,
+      path,
+      params,
+      apiKey,
+    })
+    return response as ResponseMessage<T>
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : 'コンテントスクリプトへの通信に失敗しました',
+    }
+  }
+}
+
+/**
  * サブスクリプションキャンセル
  * DELETE /v1/subscriptions/{subscriptionId}
- *
- * TODO: Chrome拡張機能のService Workerからfetchすると Chrome が自動付与する
- *   `Origin: chrome-extension://{extension_id}` ヘッダーを Cloudflare がブロックし、
- *   Stripe のバックエンドに到達する前に HTTP 429 が返される。
- *   GETリクエストは通過するが、DELETEなどの書き込み操作のみブロックされることを確認済み。
- *   対策: 社内プロキシ（例: stg.form.run の Rails エンドポイント）経由でキャンセルを
- *   実行するよう変更することで回避できる。
+ * SW から直接 fetch すると Origin: chrome-extension:// が付与されて Cloudflare にブロックされるため、
+ * stg.form.run に挿入したコンテントスクリプト経由で実行する
  */
 async function handleCancelSubscription(
   subscriptionId: string
 ): Promise<ResponseMessage<CancelSubscriptionData>> {
-  const result = await stripeRequest<StripeSubscription>('DELETE', `/v1/subscriptions/${subscriptionId}`)
+  const result = await proxyRequest<StripeSubscription>('DELETE', `/v1/subscriptions/${subscriptionId}`)
 
   if (!result.ok) {
     return result
@@ -343,12 +381,13 @@ async function handleListInvoices(customerId: string): Promise<ResponseMessage<L
 /**
  * キャッシュ残高追加
  * POST /v1/test_helpers/customers/{customerId}/fund_cash_balance
+ * 書き込み操作のため、コンテントスクリプト経由で実行する
  */
 async function handleAddCashBalance(
   customerId: string,
   amount: number
 ): Promise<ResponseMessage<AddCashBalanceData>> {
-  const result = await stripeRequest<{ amount: number; currency: string }>(
+  const result = await proxyRequest<{ amount: number; currency: string }>(
     'POST',
     `/v1/test_helpers/customers/${customerId}/fund_cash_balance`,
     {

--- a/src/content/stripe-proxy.ts
+++ b/src/content/stripe-proxy.ts
@@ -1,0 +1,78 @@
+/// <reference types="chrome" />
+
+// Content Script: Stripe API プロキシ
+// stg.form.run ページに挿入され、SW からの依頼を受けて Stripe API へ fetch する。
+// ページの Origin (https://stg.form.run) で fetch するため Cloudflare のブロックを回避できる。
+
+const STRIPE_API_BASE = 'https://api.stripe.com'
+
+interface ProxyRequest {
+  action: 'STRIPE_PROXY'
+  method: 'DELETE' | 'POST'
+  path: string
+  params?: Record<string, string>
+  apiKey: string
+}
+
+interface ProxyResponse {
+  ok: boolean
+  data?: unknown
+  error?: string
+  code?: string
+}
+
+chrome.runtime.onMessage.addListener(
+  (message: ProxyRequest, _sender, sendResponse) => {
+    if (message.action !== 'STRIPE_PROXY') return false
+
+    handleProxyRequest(message)
+      .then(sendResponse)
+      .catch((err) => {
+        sendResponse({
+          ok: false,
+          error: err instanceof Error ? err.message : 'プロキシリクエストに失敗しました',
+        })
+      })
+
+    return true // 非同期応答のため必須
+  }
+)
+
+async function handleProxyRequest(req: ProxyRequest): Promise<ProxyResponse> {
+  const url = `${STRIPE_API_BASE}${req.path}`
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${req.apiKey}`,
+    'Stripe-Version': '2020-08-27',
+  }
+
+  let body: string | undefined
+  if (req.params) {
+    const bodyStr = new URLSearchParams(req.params).toString()
+    if (bodyStr) {
+      body = bodyStr
+      headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    }
+  }
+
+  const response = await fetch(url, { method: req.method, headers, body })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({ error: { message: `HTTP ${response.status}`, code: undefined } }))
+
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, error: 'APIキーが無効です。再設定してください。', code: 'API_KEY_INVALID' }
+    }
+    if (response.status === 429) {
+      return { ok: false, error: 'リクエストが多すぎます。少し待ってから再試行してください。', code: 'RATE_LIMIT' }
+    }
+
+    return {
+      ok: false,
+      error: errorData?.error?.message ?? `HTTP ${response.status}`,
+      code: errorData?.error?.code,
+    }
+  }
+
+  const data = await response.json()
+  return { ok: true, data }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,18 @@
   "name": "Stripe Test Helper",
   "version": "1.0.0",
   "description": "Stripe テスト環境操作ヘルパー（QA・開発チーム向け）",
-  "permissions": ["storage"],
-  "host_permissions": ["https://api.stripe.com/*"],
+  "permissions": ["storage", "tabs"],
+  "host_permissions": [
+    "https://api.stripe.com/*",
+    "https://stg.form.run/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["https://stg.form.run/*"],
+      "js": ["content-script.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "background": {
     "service_worker": "service-worker.js"
   },


### PR DESCRIPTION
## Summary
- SW から直接 fetch すると `Origin: chrome-extension://` が付与され Cloudflare にブロックされ DELETE/POST が届かない問題を修正
- `stg.form.run` に挿入したコンテントスクリプト経由でリクエストすることで、ページの Origin (`https://stg.form.run`) が使われ Cloudflare のルールを回避
- CANCEL_SUBSCRIPTION・ADD_CASH_BALANCE の両操作を `proxyRequest()` 経由に変更

## 変更ファイル
- `src/content/stripe-proxy.ts` — 新規: `STRIPE_PROXY` メッセージを受け取り Stripe API へ fetch するコンテントスクリプト
- `src/manifest.json` — `tabs` permission、`content_scripts`（stg.form.run）、`host_permissions` 追加
- `src/background/service-worker.ts` — `proxyRequest()` を追加し CS 経由の書き込みに切り替え
- `build.js` — `content-script.js` のビルドエントリポイントを追加

## Test plan
- [ ] stg.form.run タブを開いた状態でサブスクリプションキャンセルが成功することを確認
- [ ] stg.form.run タブが閉じている場合に「タブが見つかりません」エラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)