### PR TITLE
feat: S06（Invoice一覧）・S07（残高追加確認）を実装

### DIFF
--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -11,6 +11,8 @@ import { s02Search } from './screens/s02-search'
 import { s03Menu } from './screens/s03-menu'
 import { s04Subscriptions } from './screens/s04-subscriptions'
 import { s05CancelConfirm } from './screens/s05-cancel-confirm'
+import { s06Invoices } from './screens/s06-invoices'
+import { s07BalanceConfirm } from './screens/s07-balance-confirm'
 
 // アプリケーション状態
 const appState: AppState = {}
@@ -22,85 +24,8 @@ const screens: Record<ScreenId, Screen> = {
   S03: s03Menu,
   S04: s04Subscriptions,
   S05: s05CancelConfirm,
-  S06: createPlaceholderScreen('S06', 'Invoice一覧'),
-  S07: createPlaceholderScreen('S07', '残高追加確認'),
-}
-
-/**
- * プレースホルダー画面を生成（Step 6で実装まで一時的に使用）
- */
-function createPlaceholderScreen(id: ScreenId, title: string): Screen {
-  return {
-    render(state: AppState, navigate) {
-      const container = document.createElement('div')
-      container.style.cssText = `
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        padding: 40px;
-        text-align: center;
-      `
-
-      const heading = document.createElement('h1')
-      heading.textContent = title
-      heading.style.cssText = `
-        font-size: 20px;
-        font-weight: 600;
-        color: #1a1a2e;
-        margin-bottom: 16px;
-      `
-
-      const description = document.createElement('p')
-      description.textContent = `画面ID: ${id}`
-      description.style.cssText = `
-        font-size: 14px;
-        color: #6b7280;
-        margin-bottom: 24px;
-      `
-
-      const info = document.createElement('pre')
-      info.textContent = JSON.stringify(state, null, 2)
-      info.style.cssText = `
-        font-size: 12px;
-        color: #4b5563;
-        background: #f3f4f6;
-        padding: 16px;
-        border-radius: 6px;
-        text-align: left;
-        overflow: auto;
-        max-width: 100%;
-        max-height: 300px;
-      `
-
-      container.appendChild(heading)
-      container.appendChild(description)
-      container.appendChild(info)
-
-      // テスト用の戻るボタン（S02以外の画面に表示）
-      if (id !== 'S01' && id !== 'S02') {
-        const backButton = document.createElement('button')
-        backButton.textContent = 'S02に戻る'
-        backButton.style.cssText = `
-          margin-top: 24px;
-          padding: 10px 20px;
-          background-color: #635bff;
-          color: white;
-          border: none;
-          border-radius: 6px;
-          font-size: 14px;
-          font-weight: 500;
-          cursor: pointer;
-        `
-        backButton.addEventListener('click', () => navigate('S02'))
-        container.appendChild(backButton)
-      }
-
-      return container
-    },
-  }
+  S06: s06Invoices,
+  S07: s07BalanceConfirm,
 }
 
 /**

--- a/src/popup/screens/s06-invoices.ts
+++ b/src/popup/screens/s06-invoices.ts
@@ -1,0 +1,380 @@
+// S06: Invoice一覧画面
+// 請求書一覧を表示し、金額を選択して残高追加確認画面へ進む
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import type { StripeInvoice } from '../../types/stripe'
+import { sendMessage } from '../send-message'
+import { createLoadingSpinner } from '../components/loading-spinner'
+
+let isFetching = false
+
+export const s06Invoices: Screen = {
+  render(state: AppState, navigate: NavigateFn): HTMLElement {
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    header.appendChild(createBackButton(() => navigate('S03')))
+    header.appendChild(el('h1', '現金残高を追加', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `))
+    container.appendChild(header)
+
+    // ── 顧客名サブヘッダー ──
+    const subHeader = div(`
+      padding: 10px 20px;
+      background: #fff;
+      border-bottom: 1px solid #e5e7eb;
+      flex-shrink: 0;
+    `)
+    subHeader.appendChild(el('p', state.customer?.name ?? state.customer?.email ?? '', `
+      font-size: 12px;
+      color: #6b7280;
+    `))
+    container.appendChild(subHeader)
+
+    // ── スクロールエリア ──
+    const scrollArea = div(`
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    `)
+    container.appendChild(scrollArea)
+
+    // 手動入力エリア（常に表示）
+    scrollArea.appendChild(createManualInputArea(navigate))
+
+    // Invoice リストエリア
+    const invoiceArea = div(`display: flex; flex-direction: column; gap: 0;`)
+    scrollArea.appendChild(invoiceArea)
+
+    if (state.invoices) {
+      renderInvoiceList(invoiceArea, state.invoices, navigate)
+    } else {
+      fetchAndRender(invoiceArea, state, navigate)
+    }
+
+    return container
+  },
+}
+
+function createManualInputArea(navigate: NavigateFn): HTMLElement {
+  const wrap = div(`
+    background: #fff;
+    border-radius: 10px;
+    border: 1px solid #e5e7eb;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `)
+
+  wrap.appendChild(el('p', '金額を入力', `
+    font-size: 12px;
+    font-weight: 600;
+    color: #374151;
+  `))
+
+  const row = div(`display: flex; gap: 8px; align-items: center;`)
+
+  const input = document.createElement('input')
+  input.type = 'number'
+  input.min = '1'
+  input.placeholder = '例: 1980'
+  input.style.cssText = `
+    flex: 1;
+    padding: 9px 12px;
+    border: 1.5px solid #e5e7eb;
+    border-radius: 8px;
+    font-size: 14px;
+    color: #1a1a2e;
+    outline: none;
+    transition: border-color 0.15s;
+  `
+  input.addEventListener('focus', () => { input.style.borderColor = '#059669' })
+  input.addEventListener('blur', () => { input.style.borderColor = '#e5e7eb' })
+
+  const unit = el('span', '円', `font-size: 14px; color: #6b7280; flex-shrink: 0;`)
+
+  const confirmBtn = document.createElement('button')
+  confirmBtn.textContent = '確認'
+  confirmBtn.style.cssText = `
+    padding: 9px 16px;
+    background: #059669;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+    flex-shrink: 0;
+  `
+  confirmBtn.addEventListener('mouseenter', () => { confirmBtn.style.background = '#047857' })
+  confirmBtn.addEventListener('mouseleave', () => { confirmBtn.style.background = '#059669' })
+  confirmBtn.addEventListener('click', () => {
+    const val = parseInt(input.value, 10)
+    if (!val || val <= 0) {
+      input.style.borderColor = '#dc2626'
+      input.focus()
+      return
+    }
+    navigate('S07', { cashAmount: val, selectedInvoice: undefined })
+  })
+
+  row.appendChild(input)
+  row.appendChild(unit)
+  row.appendChild(confirmBtn)
+  wrap.appendChild(row)
+
+  return wrap
+}
+
+async function fetchAndRender(
+  area: HTMLElement,
+  state: AppState,
+  navigate: NavigateFn
+): Promise<void> {
+  if (isFetching) return
+  const customerId = state.customer?.id
+  if (!customerId) {
+    showMessage(area, '⚠️', '顧客情報がありません', '#dc2626')
+    return
+  }
+
+  isFetching = true
+  area.replaceChildren(createLoadingSpinner('請求書を読み込み中...'))
+
+  const res = await sendMessage<{ invoices: StripeInvoice[] }>({
+    action: 'LIST_INVOICES',
+    payload: { customerId },
+  })
+
+  isFetching = false
+
+  if (!res.ok) {
+    showMessage(area, '⚠️', res.error, '#dc2626')
+    return
+  }
+
+  navigate('S06', { invoices: res.data.invoices })
+}
+
+function renderInvoiceList(
+  area: HTMLElement,
+  invoices: StripeInvoice[],
+  navigate: NavigateFn
+): void {
+  area.replaceChildren()
+
+  const sectionLabel = el('p', '請求書から金額を選択', `
+    font-size: 12px;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 8px;
+  `)
+  area.appendChild(sectionLabel)
+
+  if (invoices.length === 0) {
+    showMessage(area, '📄', '請求書がありません', '#6b7280')
+    return
+  }
+
+  const count = el('p', `${invoices.length} 件`, `
+    font-size: 12px;
+    color: #6b7280;
+    margin-bottom: 10px;
+  `)
+  area.appendChild(count)
+
+  for (const invoice of invoices) {
+    area.appendChild(createInvoiceCard(invoice, navigate))
+  }
+}
+
+function createInvoiceCard(invoice: StripeInvoice, navigate: NavigateFn): HTMLElement {
+  const isPaid = invoice.status === 'paid'
+
+  const card = div(`
+    background: #fff;
+    border-radius: 10px;
+    padding: 12px 14px;
+    margin-bottom: 8px;
+    border: 1.5px solid #e5e7eb;
+    cursor: ${isPaid ? 'default' : 'pointer'};
+    opacity: ${isPaid ? '0.6' : '1'};
+    transition: border-color 0.15s, box-shadow 0.15s;
+  `)
+
+  if (!isPaid) {
+    card.addEventListener('mouseenter', () => {
+      card.style.borderColor = '#059669'
+      card.style.boxShadow = '0 2px 8px rgba(5,150,105,0.12)'
+    })
+    card.addEventListener('mouseleave', () => {
+      card.style.borderColor = '#e5e7eb'
+      card.style.boxShadow = 'none'
+    })
+    card.addEventListener('click', () => {
+      navigate('S07', { cashAmount: invoice.amount_due, selectedInvoice: invoice })
+    })
+  }
+
+  // 1行目: ステータスバッジ + 番号
+  const row1 = div(`display: flex; align-items: center; gap: 8px; margin-bottom: 6px;`)
+  row1.appendChild(createStatusBadge(invoice.status))
+
+  const invoiceNum = el('p', invoice.number ?? invoice.id, `
+    font-size: 12px;
+    color: #6b7280;
+    font-family: monospace;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `)
+  row1.appendChild(invoiceNum)
+
+  // 2行目: 金額 + 日付
+  const row2 = div(`display: flex; justify-content: space-between; align-items: center;`)
+
+  const amountEl = el('p', formatAmount(invoice), `
+    font-size: 14px;
+    font-weight: 700;
+    color: #1a1a2e;
+  `)
+
+  const dateEl = el('p', formatDate(invoice.created), `
+    font-size: 11px;
+    color: #9ca3af;
+  `)
+
+  row2.appendChild(amountEl)
+  row2.appendChild(dateEl)
+
+  card.appendChild(row1)
+  card.appendChild(row2)
+
+  if (isPaid) {
+    card.appendChild(el('p', '支払済みのため選択できません', `
+      font-size: 11px;
+      color: #9ca3af;
+      margin-top: 4px;
+    `))
+  }
+
+  return card
+}
+
+function createStatusBadge(status: StripeInvoice['status']): HTMLElement {
+  const map: Record<string, { label: string; bg: string; color: string }> = {
+    draft:        { label: '下書き',   bg: '#f3f4f6', color: '#6b7280' },
+    open:         { label: '未払い',   bg: '#fef3c7', color: '#92400e' },
+    paid:         { label: '支払済み', bg: '#d1fae5', color: '#065f46' },
+    uncollectible:{ label: '回収不能', bg: '#fee2e2', color: '#991b1b' },
+    void:         { label: '無効',     bg: '#f3f4f6', color: '#6b7280' },
+  }
+  const { label, bg, color } = map[status] ?? { label: status, bg: '#f3f4f6', color: '#6b7280' }
+
+  return el('span', label, `
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: ${bg};
+    color: ${color};
+    white-space: nowrap;
+    flex-shrink: 0;
+  `)
+}
+
+function formatAmount(invoice: StripeInvoice): string {
+  return new Intl.NumberFormat('ja-JP', {
+    style: 'currency',
+    currency: invoice.currency.toUpperCase(),
+    maximumFractionDigits: 0,
+  }).format(invoice.amount_due)
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts * 1000).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  })
+}
+
+function showMessage(area: HTMLElement, icon: string, message: string, color: string): void {
+  area.replaceChildren()
+  const wrap = div(`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 20px;
+    text-align: center;
+    gap: 12px;
+  `)
+  wrap.appendChild(el('p', icon, `font-size: 32px; line-height: 1;`))
+  wrap.appendChild(el('p', message, `font-size: 13px; color: ${color}; line-height: 1.5;`))
+  area.appendChild(wrap)
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}
+
+function createBackButton(onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.textContent = '←'
+  btn.style.cssText = `
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: #6b7280;
+    padding: 2px 6px 2px 0;
+    line-height: 1;
+    transition: color 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => { btn.style.color = '#1a1a2e' })
+  btn.addEventListener('mouseleave', () => { btn.style.color = '#6b7280' })
+  btn.addEventListener('click', onClick)
+  return btn
+}

--- a/src/popup/screens/s07-balance-confirm.ts
+++ b/src/popup/screens/s07-balance-confirm.ts
@@ -1,0 +1,287 @@
+// S07: 残高追加確認画面
+
+import type { Screen, AppState, NavigateFn } from '../types'
+import { sendMessage } from '../send-message'
+
+export const s07BalanceConfirm: Screen = {
+  render(state: AppState, navigate: NavigateFn): HTMLElement {
+    const customer = state.customer
+    const amount = state.cashAmount ?? 0
+
+    const container = div(`
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: #f8f9fa;
+    `)
+
+    // ── ヘッダー ──
+    const header = div(`
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 20px;
+      border-bottom: 1px solid #e5e7eb;
+      background: #fff;
+      flex-shrink: 0;
+    `)
+    header.appendChild(createBackButton(() => navigate('S06')))
+    header.appendChild(el('h1', '残高追加確認', `
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a2e;
+    `))
+    container.appendChild(header)
+
+    // ── 本文 ──
+    const body = div(`
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      padding: 20px;
+      gap: 16px;
+      overflow-y: auto;
+    `)
+
+    // 確認カード
+    const card = div(`
+      background: #fff;
+      border-radius: 10px;
+      border: 1px solid #e5e7eb;
+      overflow: hidden;
+    `)
+
+    card.appendChild(el('p', '追加内容', `
+      font-size: 11px;
+      font-weight: 600;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 12px 16px 8px;
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+    `))
+
+    const rows: [string, string, boolean][] = [
+      ['顧客名',      customer?.name ?? customer?.email ?? '-', false],
+      ['顧客ID',      customer?.id ?? '-',                      true],
+      ['追加金額',    formatAmount(amount),                     false],
+      ['通貨',        'JPY',                                    false],
+    ]
+
+    // Invoice から来た場合は請求書番号も表示
+    if (state.selectedInvoice) {
+      rows.push(['請求書番号', state.selectedInvoice.number ?? state.selectedInvoice.id, true])
+    }
+
+    for (const [label, value, mono] of rows) {
+      const row = div(`
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 10px 16px;
+        border-bottom: 1px solid #f3f4f6;
+      `)
+      row.appendChild(el('span', label, `
+        font-size: 12px;
+        color: #6b7280;
+        flex-shrink: 0;
+      `))
+      row.appendChild(el('span', value, `
+        font-size: 12px;
+        font-weight: 500;
+        color: #1a1a2e;
+        text-align: right;
+        word-break: break-all;
+        font-family: ${mono ? 'monospace' : 'inherit'};
+      `))
+      card.appendChild(row)
+    }
+
+    body.appendChild(card)
+
+    // 金額強調表示
+    const amountHighlight = div(`
+      background: #ecfdf5;
+      border: 1px solid #a7f3d0;
+      border-radius: 10px;
+      padding: 16px;
+      text-align: center;
+    `)
+    amountHighlight.appendChild(el('p', '追加される金額', `
+      font-size: 12px;
+      color: #065f46;
+      margin-bottom: 6px;
+    `))
+    amountHighlight.appendChild(el('p', formatAmount(amount), `
+      font-size: 28px;
+      font-weight: 800;
+      color: #065f46;
+      line-height: 1;
+    `))
+    body.appendChild(amountHighlight)
+
+    // スペーサー
+    body.appendChild(div(`flex: 1;`))
+
+    // ── ボタンエリア ──
+    const btnArea = div(`display: flex; flex-direction: column; gap: 10px;`)
+
+    const errorText = el('p', '', `
+      font-size: 12px;
+      color: #dc2626;
+      text-align: center;
+      min-height: 16px;
+      line-height: 1.4;
+    `)
+    btnArea.appendChild(errorText)
+
+    // 追加ボタン
+    const addBtn = document.createElement('button')
+    addBtn.textContent = '残高を追加する'
+    addBtn.style.cssText = `
+      width: 100%;
+      padding: 12px;
+      background: #059669;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s;
+    `
+    addBtn.addEventListener('mouseenter', () => { if (!addBtn.disabled) addBtn.style.background = '#047857' })
+    addBtn.addEventListener('mouseleave', () => { if (!addBtn.disabled) addBtn.style.background = '#059669' })
+
+    addBtn.addEventListener('click', async () => {
+      if (!customer?.id) return
+      errorText.textContent = ''
+      addBtn.textContent = '追加中...'
+      addBtn.disabled = true
+      addBtn.style.background = '#9ca3af'
+
+      const res = await sendMessage({
+        action: 'ADD_CASH_BALANCE',
+        payload: { customerId: customer.id, amount },
+      })
+
+      if (!res.ok) {
+        errorText.textContent = res.error
+        addBtn.textContent = '残高を追加する'
+        addBtn.disabled = false
+        addBtn.style.background = '#059669'
+        return
+      }
+
+      // 成功 → S03に戻る
+      navigate('S03', { invoices: undefined, selectedInvoice: undefined, cashAmount: undefined })
+      showSuccessToast(formatAmount(amount))
+    })
+
+    // 戻るボタン
+    const backBtn = document.createElement('button')
+    backBtn.textContent = '戻る'
+    backBtn.style.cssText = `
+      width: 100%;
+      padding: 11px;
+      background: #fff;
+      color: #374151;
+      border: 1.5px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s;
+    `
+    backBtn.addEventListener('mouseenter', () => { backBtn.style.background = '#f9fafb' })
+    backBtn.addEventListener('mouseleave', () => { backBtn.style.background = '#fff' })
+    backBtn.addEventListener('click', () => navigate('S06'))
+
+    btnArea.appendChild(addBtn)
+    btnArea.appendChild(backBtn)
+    body.appendChild(btnArea)
+    container.appendChild(body)
+
+    return container
+  },
+}
+
+function formatAmount(amount: number): string {
+  return new Intl.NumberFormat('ja-JP', {
+    style: 'currency',
+    currency: 'JPY',
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+function showSuccessToast(amount: string): void {
+  const toast = document.createElement('div')
+  toast.textContent = `✅ ${amount} の残高を追加しました`
+  toast.style.cssText = `
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #065f46;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    z-index: 9999;
+    white-space: nowrap;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    animation: fadeIn 0.2s ease;
+  `
+
+  if (!document.getElementById('toast-style')) {
+    const style = document.createElement('style')
+    style.id = 'toast-style'
+    style.textContent = `@keyframes fadeIn { from { opacity: 0; transform: translateX(-50%) translateY(8px); } to { opacity: 1; transform: translateX(-50%) translateY(0); } }`
+    document.head.appendChild(style)
+  }
+
+  document.body.appendChild(toast)
+  setTimeout(() => toast.remove(), 2500)
+}
+
+// ── ユーティリティ ──
+
+function div(css: string): HTMLDivElement {
+  const d = document.createElement('div')
+  d.style.cssText = css
+  return d
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  text: string,
+  css = ''
+): HTMLElementTagNameMap[K] {
+  const e = document.createElement(tag)
+  e.textContent = text
+  if (css) e.style.cssText = css
+  return e
+}
+
+function createBackButton(onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button')
+  btn.textContent = '←'
+  btn.style.cssText = `
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    color: #6b7280;
+    padding: 2px 6px 2px 0;
+    line-height: 1;
+    transition: color 0.15s;
+  `
+  btn.addEventListener('mouseenter', () => { btn.style.color = '#1a1a2e' })
+  btn.addEventListener('mouseleave', () => { btn.style.color = '#6b7280' })
+  btn.addEventListener('click', onClick)
+  return btn
+}


### PR DESCRIPTION
## Summary
- S06・S07 を実装し、現金残高追加フロー（S03 → S06 → S07 → S03）を完成させる
- プレースホルダー画面を削除し、popup.ts をシンプル化

## 変更内容
- `src/popup/screens/s06-invoices.ts` — 新規: Invoice一覧 + 手動入力で金額を選択
- `src/popup/screens/s07-balance-confirm.ts` — 新規: 追加内容確認 → ADD_CASH_BALANCE 実行
- `src/popup/popup.ts` — S06/S07 のプレースホルダーを実装画面に差し替え・不要コード削除

## S06 の機能
- 手動入力フォームで任意の金額を入力して確認画面へ進める
- Invoice一覧から未払い/下書きをクリックして金額をセット（支払済みはグレーアウト）
- isFetching フラグで重複 fetch を防止

## S07 の機能
- 顧客名・顧客ID・追加金額・通貨を確認カードで表示
- Invoice から遷移した場合は請求書番号も表示
- 成功時はトースト通知して S03 へ戻る

## Test plan
- [ ] S03「現金残高を追加」→ S06 へ遷移し Invoice 一覧が表示される
- [ ] Invoice をクリック → S07 に金額がセットされて遷移する
- [ ] 手動入力で金額を入力 → 「確認」→ S07 へ遷移する
- [ ] S07「残高を追加する」→ 成功トーストが表示されて S03 に戻る
- [ ] stg.form.run タブが開いていない場合にエラーが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)