### PR TITLE
fix: .gitignore に *.pem を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+*.pem


### PR DESCRIPTION
公開リポジトリ化に備え、拡張機能の秘密鍵ファイル（.pem）が
誤ってコミットされないよう .gitignore に追加。