### PR TITLE
fix: 複数プランの全アイテム表示・5件上限・ボタン固定レイアウトに対応

### DIFF
--- a/src/popup/screens/s04-subscriptions.ts
+++ b/src/popup/screens/s04-subscriptions.ts
@@ -113,14 +113,19 @@ function renderList(
     return
   }
 
-  const count = el('p', `${subscriptions.length} 件`, `
+  const MAX_SUBSCRIPTIONS = 5
+  const displayed = subscriptions.slice(0, MAX_SUBSCRIPTIONS)
+  const countText = subscriptions.length > MAX_SUBSCRIPTIONS
+    ? `${subscriptions.length} 件中 ${MAX_SUBSCRIPTIONS} 件を表示`
+    : `${subscriptions.length} 件`
+  const count = el('p', countText, `
     font-size: 12px;
     color: #6b7280;
     margin-bottom: 10px;
   `)
   area.appendChild(count)
 
-  for (const sub of subscriptions) {
+  for (const sub of displayed) {
     area.appendChild(createSubscriptionCard(sub, navigate))
   }
 }
@@ -155,28 +160,38 @@ function createSubscriptionCard(sub: StripeSubscription, navigate: NavigateFn): 
   const row1 = div(`display: flex; align-items: center; gap: 8px; margin-bottom: 8px;`)
   row1.appendChild(createStatusBadge(sub.status))
 
+  const MAX_ITEMS = 5
   const nameBlock = div(`flex: 1; overflow: hidden;`)
-  const planName = el('p', getPlanName(sub), `
-    font-size: 13px;
-    font-weight: 600;
-    color: #1a1a2e;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `)
-  nameBlock.appendChild(planName)
-
-  const item0 = sub.items.data[0]
-  if (item0) {
-    const priceId = el('p', item0.price.id, `
+  if (sub.items.data.length === 0) {
+    nameBlock.appendChild(el('p', '(プランなし)', `font-size: 13px; font-weight: 600; color: #1a1a2e;`))
+  }
+  for (const item of sub.items.data.slice(0, MAX_ITEMS)) {
+    const product = item.price.product
+    const name = typeof product === 'object' ? product.name : '(プラン名不明)'
+    nameBlock.appendChild(el('p', name, `
+      font-size: 13px;
+      font-weight: 600;
+      color: #1a1a2e;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    `))
+    nameBlock.appendChild(el('p', item.price.id, `
       font-size: 10px;
       color: #9ca3af;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       margin-top: 2px;
-    `)
-    nameBlock.appendChild(priceId)
+      margin-bottom: 4px;
+    `))
+  }
+  if (sub.items.data.length > MAX_ITEMS) {
+    nameBlock.appendChild(el('p', `他 ${sub.items.data.length - MAX_ITEMS} 件`, `
+      font-size: 11px;
+      color: #9ca3af;
+      margin-top: 2px;
+    `))
   }
 
   row1.appendChild(nameBlock)
@@ -239,14 +254,6 @@ function createStatusBadge(status: StripeSubscriptionStatus): HTMLElement {
     flex-shrink: 0;
   `)
   return badge
-}
-
-function getPlanName(sub: StripeSubscription): string {
-  const item = sub.items.data[0]
-  if (!item) return '(プランなし)'
-  const product = item.price.product
-  if (typeof product === 'object') return product.name
-  return '(プラン名不明)'
 }
 
 function formatAmount(sub: StripeSubscription): string {

--- a/src/popup/screens/s05-cancel-confirm.ts
+++ b/src/popup/screens/s05-cancel-confirm.ts
@@ -85,8 +85,17 @@ export const s05CancelConfirm: Screen = {
     `)
     card.appendChild(cardTitle)
 
+    const planRows: [string, string][] = sub
+      ? sub.items.data.map((item, i) => {
+          const product = item.price.product
+          const name = typeof product === 'object' ? product.name : item.price.id
+          const label = sub.items.data.length > 1 ? `プラン ${i + 1}` : 'プラン'
+          return [label, name] as [string, string]
+        })
+      : [['プラン', '-']]
+
     const rows: [string, string][] = [
-      ['プラン',       getPlanName(sub)],
+      ...planRows,
       ['ステータス',   getStatusLabel(sub?.status)],
       ['金額',         formatAmount(sub)],
       ['現在の期間',   formatPeriod(sub)],
@@ -122,12 +131,16 @@ export const s05CancelConfirm: Screen = {
 
     body.appendChild(card)
 
-    // ── スペーサー ──
-    const spacer = div(`flex: 1;`)
-    body.appendChild(spacer)
-
     // ── ボタンエリア ──
-    const btnArea = div(`display: flex; flex-direction: column; gap: 10px;`)
+    const btnArea = div(`
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 16px 20px;
+      background: #f8f9fa;
+      border-top: 1px solid #e5e7eb;
+      flex-shrink: 0;
+    `)
 
     // エラーメッセージ
     const errorText = el('p', '', `
@@ -203,8 +216,8 @@ export const s05CancelConfirm: Screen = {
 
     btnArea.appendChild(cancelBtn)
     btnArea.appendChild(backBtnBottom)
-    body.appendChild(btnArea)
     container.appendChild(body)
+    container.appendChild(btnArea)
 
     return container
   },
@@ -243,15 +256,6 @@ function showSuccessToast(): void {
 }
 
 // ── ヘルパー ──
-
-function getPlanName(sub: AppState['selectedSubscription']): string {
-  if (!sub) return '-'
-  const item = sub.items.data[0]
-  if (!item) return '(プランなし)'
-  const product = item.price.product
-  if (typeof product === 'object') return product.name
-  return item.price.id
-}
 
 function getStatusLabel(status: string | undefined): string {
   const map: Record<string, string> = {


### PR DESCRIPTION
## Summary

- S04/S05: サブスクリプションアイテムを全件表示（`items.data[0]` のみから変更）
- S04: カード内プランアイテムを最大5件に制限、超過分は「他N件」表示
- S04: サブスクリプション一覧を最大5件に制限
- S05: プランが複数の場合「プランN」ラベルで個別行表示
- S05: ボタンエリアをスクロール領域外に固定し、コンテンツ切れを解消

## Test plan

- [ ] サブスクリプションが1件の場合、プラン名が正しく表示される
- [ ] サブスクリプションに複数アイテムがある場合、全プラン名が表示される
- [ ] プランアイテムが5件超の場合、「他N件」と表示される
- [ ] サブスクリプション一覧が6件以上ある場合、「N件中5件を表示」と表示される
- [ ] キャンセル確認画面でプランが複数の場合「プラン1」「プラン2」と表示される
- [ ] キャンセル確認画面でコンテンツが多い場合もボタンが常に下部に固定される

🤖 Generated with [Claude Code](https://claude.com/claude-code)